### PR TITLE
Update CategoryList.php

### DIFF
--- a/app/code/community/VinaiKopp/ProductCategories/Block/CategoryList.php
+++ b/app/code/community/VinaiKopp/ProductCategories/Block/CategoryList.php
@@ -96,10 +96,13 @@ class VinaiKopp_ProductCategories_Block_CategoryList extends Mage_Catalog_Block_
      */
     public function getCategories()
     {
+        $rootCategoryId = Mage::app()->getStore()->getRootCategoryId();
+        
         $categories = $this->_getData('categories');
         if (is_null($categories)) {
             $categories = $this->getProduct()->getCategoryCollection()
                 ->addIsActiveFilter()
+                ->addAttributeToFilter('path', array('like' => "1/{$rootCategoryId}/%"))
                 ->addNameToResult()
                 ->addUrlRewriteToResult()->getItems();
             $categories = $this->_filterOutCategoriesThatAreAlsoParent($categories);


### PR DESCRIPTION
Add Store Filter

if you have a multidomain setup then be able to see all the product categories assigned. but that leads to 404 because the categories are not available in each store. this small fix resolves this
